### PR TITLE
Update sysmo-usim-tool repository URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Consult [awesome-telco](https://github.com/ravens/awesome-telco) for more genera
 ## SIM
 
 - [pysim](https://github.com/osmocom/pysim) - A python tool to program SIMs.
-- [sysmo-usim-tool](https://git.sysmocom.de/sysmo-usim-tool/) - Tool to (re)configure the sysmoUSIM-SJS1 cards.
+- [sysmo-usim-tool](https://gitea.sysmocom.de/sysmocom/sysmo-usim-tool/) - Tool to (re)configure the sysmoUSIM-SJS1 cards.
 
 ## UE/CPE
 


### PR DESCRIPTION
This PR updates the repository URL for sysmo-usim-tool from [https://git.sysmocom.de/sysmo-usim-tool](https://git.sysmocom.de/sysmo-usim-tool/) to [https://gitea.sysmocom.de/sysmocom/sysmo-usim-tool](https://gitea.sysmocom.de/sysmocom/sysmo-usim-tool/).